### PR TITLE
Added REQUIRED_FIELDS to User

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/apps/users/models.py
+++ b/{{cookiecutter.project_slug}}/backend/apps/users/models.py
@@ -50,6 +50,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     # Fields settings
     EMAIL_FIELD = 'email'
     USERNAME_FIELD = 'username'
+    REQUIRED_FIELDS = ['email']
 
     objects = UserManager()
 


### PR DESCRIPTION
Manage.py createsuperuser doesn't ask for an email adress due to the REQUIRED_FIELDS not being set on the subclassed user model. This causes the createsuperuser command to fail since no email adress is given. Adding REQUIRED_FIELDS = ['email'] fixes this. Ref https://docs.djangoproject.com/en/3.0/topics/auth/customizing/#django.contrib.auth.models.CustomUser.REQUIRED_FIELDS