### PR TITLE
Compatibility issue with vue and vue-template-compiler versions

### DIFF
--- a/{{cookiecutter.project_slug}}/frontend/package.json
+++ b/{{cookiecutter.project_slug}}/frontend/package.json
@@ -38,7 +38,7 @@
     "vue-cli-plugin-apollo": "^0.16.4",
     "sass-loader": "^7.1.0",
     "@sentry/cli": "1.51.1",
-    "vue-template-compiler": "^2.5.17"
+    "vue-template-compiler": "2.6.11"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
Fix for https://github.com/grantmcconnaughey/cookiecutter-django-vue-graphql-aws/issues/8
Version compatibility mismatch between vue (2.6.11) and vue-template-compiler(2.6.12)
